### PR TITLE
Only use <name>.<ext> in top level for default type.

### DIFF
--- a/lib/engines/classic/component-template-file-info.js
+++ b/lib/engines/classic/component-template-file-info.js
@@ -12,9 +12,9 @@ var ComponentTemplateFileInfo = ClassicFileInfo.extend({
   populateName: function() {
     this._super();
 
-    var name = this.name.replace(/^components\//, '');
+    var namespace = this.namespace.replace(/^components/, '');
 
-    return this.name = name;
+    this.namespace = namespace;
   }
 });
 

--- a/lib/engines/classic/main-file-info.js
+++ b/lib/engines/classic/main-file-info.js
@@ -23,11 +23,11 @@ var MainFileInfo = ClassicFileInfo.extend({
   },
 
   populateName: function() {
-    if (this.name) {
-      return this.name;
-    }
+    this.namespace = '';
 
-    return this.name = path.basename(this.sourceRelativePath, this.ext);
+    if (!this.name) {
+      this.name = path.basename(this.sourceRelativePath, this.ext);
+    }
   }
 });
 

--- a/lib/engines/classic/mixin-file-info.js
+++ b/lib/engines/classic/mixin-file-info.js
@@ -18,6 +18,7 @@ Object.defineProperty(MixinFileInfo.prototype, 'destRelativePath', {
       this.collectionGroup,
       this.collection,
       '/mixins/',
+      this.namespace,
       this.name + this.ext
     );
   }

--- a/lib/engines/classic/single-type-collection-file-info.js
+++ b/lib/engines/classic/single-type-collection-file-info.js
@@ -9,6 +9,7 @@ Object.defineProperty(SingleTypeCollectionFileInfo.prototype, 'destRelativePath'
       'src/',
       this.collectionGroup,
       this.collection,
+      this.namespace,
       this.name + this.ext
     );
   }

--- a/lib/models/file-info.js
+++ b/lib/models/file-info.js
@@ -15,6 +15,7 @@ var FileInfo = CoreObject.extend({
     this.ext = options.ext;
     this.name = options.name;
     this._bucket = options.bucket;
+    this.namespace = options.namespace;
     this.sourceRoot = options.sourceRoot;
     this.collection = options.collection;
     this.collectionGroup = options.collectionGroup;
@@ -48,18 +49,20 @@ var FileInfo = CoreObject.extend({
 
   populateName: function() {
     if (this.name) {
-      return this.name;
+      return;
     }
 
     var pathParts = this.sourceRelativePath.split('/');
     var typeFolder = pathParts[1];
 
-    var name = this.sourceRelativePath
+    var strippedRelativePath = this.sourceRelativePath
           .replace(new RegExp('^' + this.sourceRoot + '/' + typeFolder + '/'), '') // remove leading type dir
           .replace(new RegExp(this.ext + '$'), '') // remove extension
           .replace(new RegExp('/' + this.type + '$'), ''); // remove trailing type
 
-    return this.name = name;
+    var parts = strippedRelativePath.split('/');
+    this.name = parts.pop();
+    this.namespace = parts.join('/');
   },
 
   populateCollection: function() {
@@ -134,17 +137,21 @@ Object.defineProperty(FileInfo.prototype, 'destRelativePath', {
     );
 
     var singularizedCollection = inflection.singularize(this.collection);
+    var hasNamespace = !!this.namespace;
+    var isDefaultTypeForCollection = singularizedCollection === this.type;
+    var shouldUseDotForm = filesInBucket === 1 && isDefaultTypeForCollection && !hasNamespace;
     var destRelativePath;
 
-    if (filesInBucket === 1 && singularizedCollection === this.type) {
-
+    if (shouldUseDotForm) {
       destRelativePath = path.join(
         baseRelativePath,
+        this.namespace,
         this.name + this.ext
       );
     } else {
       destRelativePath = path.join(
         baseRelativePath,
+        this.namespace,
         this.name,
         this.type + this.ext
       );

--- a/test/engines/classic-test.js
+++ b/test/engines/classic-test.js
@@ -34,22 +34,22 @@ describe('classic engine', function() {
         });
       }
 
-      confirm('app/components/foo-bar.js', {type: 'component', name: 'foo-bar', collection: 'elements', collectionGroup: 'ui'});
-      confirm('app/components/foo-bar/component.js', {type: 'component', name: 'foo-bar', collection: 'elements', collectionGroup: 'ui' });
-      confirm('app/templates/components/foo-bar.hbs', {type: 'template', name: 'foo-bar', collection: 'elements', collectionGroup: 'ui'});
-      confirm('app/components/foo-bar/template.hbs', {type: 'template', name: 'foo-bar', collection: 'elements', collectionGroup: 'ui'});
-      confirm('app/routes/foo-bar.js', {type: 'route', name: 'foo-bar', collection: 'routes', collectionGroup: 'ui'});
-      confirm('app/routes/foo-bar/baz/index.js', {type: 'route', name: 'foo-bar/baz/index', collection: 'routes', collectionGroup: 'ui'});
+      confirm('app/components/foo-bar.js', {type: 'component', name: 'foo-bar', namespace: '', collection: 'elements', collectionGroup: 'ui'});
+      confirm('app/components/foo-bar/component.js', {type: 'component', name: 'foo-bar', namespace: '', collection: 'elements', collectionGroup: 'ui' });
+      confirm('app/templates/components/foo-bar.hbs', {type: 'template', name: 'foo-bar', namespace: '', collection: 'elements', collectionGroup: 'ui'});
+      confirm('app/components/foo-bar/template.hbs', {type: 'template', name: 'foo-bar', namespace: '', collection: 'elements', collectionGroup: 'ui'});
+      confirm('app/routes/foo-bar.js', {type: 'route', name: 'foo-bar', namespace: '', collection: 'routes', collectionGroup: 'ui'});
+      confirm('app/routes/foo-bar/baz/index.js', {type: 'route', name: 'index', namespace: 'foo-bar/baz', collection: 'routes', collectionGroup: 'ui'});
       confirm('app/templates/foo-bar.hbs', {type: 'template', name: 'foo-bar', collection: 'routes', collectionGroup: 'ui'});
-      confirm('app/templates/foo-bar/baz/index.hbs', {type: 'template', name: 'foo-bar/baz/index', collection: 'routes', collectionGroup: 'ui'});
-      confirm('app/adapters/application.js', {type: 'adapter', name: 'application', collection: 'models', collectionGroup: 'data' });
-      confirm('app/app.js', {type: 'main', name: 'main', collection: '', collectionGroup: ''});
-      confirm('app/router.js', {type: 'main', name: 'router', collection: 'main', collectionGroup: ''});
-      confirm('app/index.md', { name: 'index', collection: '', collectionGroup: '' });
-      confirm('app/styles/app.css', { type: 'style', name: 'app', collection: 'styles', collectionGroup: 'ui' });
-      confirm('app/styles/components/badges.css', { type: 'style', name: 'components/badges', collection: 'styles', collectionGroup: 'ui' });
-      confirm('app/mixins/foo/bar.js', { type: 'util', name: 'foo/bar', collection: 'utils' });
-      confirm('app/authorizers/oauth2.js', { type: 'authorizer', name: 'oauth2', collection: 'authorizers', collectionGroup: 'simple-auth'});
+      confirm('app/templates/foo-bar/baz/index.hbs', {type: 'template', name: 'index', namespace: 'foo-bar/baz', collection: 'routes', collectionGroup: 'ui'});
+      confirm('app/adapters/application.js', {type: 'adapter', name: 'application', namespace: '', collection: 'models', collectionGroup: 'data' });
+      confirm('app/app.js', {type: 'main', name: 'main', namespace: '', collection: '', collectionGroup: ''});
+      confirm('app/router.js', {type: 'main', name: 'router', namespace: '', collection: 'main', collectionGroup: ''});
+      confirm('app/index.md', { name: 'index', namespace: '', collection: '', collectionGroup: '' });
+      confirm('app/styles/app.css', { type: 'style', name: 'app', namespace: '', collection: 'styles', collectionGroup: 'ui' });
+      confirm('app/styles/components/badges.css', { type: 'style', name: 'badges', namespace: 'components', collection: 'styles', collectionGroup: 'ui' });
+      confirm('app/mixins/foo/bar.js', { type: 'util', name: 'bar', namespace: 'foo', collection: 'utils' });
+      confirm('app/authorizers/oauth2.js', { type: 'authorizer', name: 'oauth2', namespace: '', collection: 'authorizers', collectionGroup: 'simple-auth'});
     });
 
     describe('file info destinations', function() {
@@ -58,9 +58,9 @@ describe('classic engine', function() {
         'app/components/qux-derp/component.js': 'src/ui/elements/qux-derp/component.js',
         'app/templates/components/foo-bar.hbs': 'src/ui/elements/foo-bar/template.hbs',
         'app/components/qux-derp/template.hbs': 'src/ui/elements/qux-derp/template.hbs',
-        'app/routes/post/index.js': 'src/ui/routes/post/index.js',
+        'app/routes/post/index.js': 'src/ui/routes/post/index/route.js',
         'app/templates/post/index.hbs': 'src/ui/routes/post/index/template.hbs',
-        'app/routes/foo/bar/baz.js': 'src/ui/routes/foo/bar/baz.js',
+        'app/routes/foo/bar/baz.js': 'src/ui/routes/foo/bar/baz/route.js',
         'app/templates/foo/bar/baz.hbs': 'src/ui/routes/foo/bar/baz/template.hbs',
         'app/adapters/post.js': 'src/data/models/post/adapter.js',
         'app/serializers/post.js': 'src/data/models/post/serializer.js',
@@ -78,6 +78,8 @@ describe('classic engine', function() {
         'app/mixins/foo/bar.js': 'src/utils/mixins/foo/bar.js',
         'app/initializers/foo.js': 'src/init/initializers/foo.js',
         'app/instance-initializers/bar.js': 'src/init/instance-initializers/bar.js',
+        'app/routes/foo.js': 'src/ui/routes/foo.js',
+        'app/models/post.js': 'src/data/models/post.js',
 
         // simple auth
         'app/authorizers/oauth2.js': 'src/simple-auth/authorizers/oauth2.js'


### PR DESCRIPTION
* Add `this.namespace` to be the path up until the leaf name.
* Change recently added rules to only use `<name>.<ext>` when at the
  root of the collection.