### PR TITLE
Include static partial names in the list of renderables.

### DIFF
--- a/lib/engines/classic/template-file-info.js
+++ b/lib/engines/classic/template-file-info.js
@@ -23,17 +23,24 @@ function buildDetectorPlugin(renderables) {
   function processNode(node) {
     var renderable = node.path.original;
     logRenderable(renderable);
-    processNodeForStaticComponentHelper(node);
+    processNodeForComponentOrPartialHelper(node);
   }
 
-  function processNodeForStaticComponentHelper(node) {
-    if (node.path.original !== 'component') {
+  function processNodeForComponentOrPartialHelper(node) {
+    var nameNode;
+
+    switch (node.path.original) {
+    case 'partial':
+    case 'component':
+      nameNode = node.params[0];
+      break;
+
+    default:
       return;
     }
 
-    var componentName = node.params[0];
-    if (componentName.type === 'StringLiteral') {
-      logRenderable(componentName.value);
+    if (nameNode.type === 'StringLiteral') {
+      logRenderable(nameNode.value);
     }
   }
 
@@ -90,5 +97,6 @@ var TemplateFileInfo = ClassicFileInfo.extend({
     });
   }
 });
+
 
 module.exports = TemplateFileInfo;

--- a/test/engines/classic/template-file-info-test.js
+++ b/test/engines/classic/template-file-info-test.js
@@ -50,6 +50,7 @@ describe('template-file-info', function() {
     confirmDetectsRenderables('{{t "some thing"}}{{t "whopdee doo"}}', ['t']);
     confirmDetectsRenderables('{{derp blah="haha"}}', ['derp']);
     confirmDetectsRenderables('<div data-foo={{derp blah="haha"}}></div>', ['derp']);
+    confirmDetectsRenderables('{{partial "foo"}}', ['partial', 'foo']);
 
     // error tolerance
     confirmDetectsRenderables('<div>', []);


### PR DESCRIPTION
Addresses #27.

---

There are still some open questions about where exactly a localized partial would go in the new proposal.

Given the following route template (and assuming it was the only usage of the partial):

```hbs
{{! app/templates/posts/show.hbs }}

<div>
  {{partial "post-display"}}
</div>
```

Currently, the migrator will make the following layout:

```
src/ui/routes/posts/show/template.hbs
src/ui/routes/post-display.hbs
```

This seems non-ideal, but I am unsure what should actually happen here...