### PR TITLE
Add support for views.

### DIFF
--- a/lib/engines/classic/index.js
+++ b/lib/engines/classic/index.js
@@ -3,6 +3,7 @@ var inflection = require('inflection');
 var ClassicFileInfo = require('./classic-file-info');
 var TestFileInfo = require('./test-file-info');
 var ComponentFileInfo = require('./component-file-info');
+var ViewFileInfo = require('./view-file-info');
 var TemplateFileInfo = require('./template-file-info');
 var ComponentTemplateFileInfo = require('./component-template-file-info');
 var MainFileInfo = require('./main-file-info');
@@ -44,11 +45,14 @@ module.exports = {
         }
       }
 
-      if (topLevelDirectory === 'mixins') {
+      switch (topLevelDirectory) {
+      case 'mixins':
         return new MixinFileInfo(options);
-      } else if (topLevelDirectory === 'components') {
+      case 'components':
         return new ComponentFileInfo(options);
-      } else {
+      case 'views':
+        return new ViewFileInfo(options);
+      default:
         return new ClassicFileInfo(options);
       }
     } else if (sourceRoot === 'tests') {

--- a/lib/engines/classic/template-file-info.js
+++ b/lib/engines/classic/template-file-info.js
@@ -4,7 +4,7 @@ var existsSync = require('exists-sync');
 var compile = require('htmlbars').compile;
 var ClassicFileInfo = require('./classic-file-info');
 
-function buildDetectorPlugin(renderables) {
+function buildDetectorPlugin(fileInfo) {
   function Detector(options) {
     this.options = options;
     this.syntax = null; // set by HTMLBars
@@ -24,6 +24,7 @@ function buildDetectorPlugin(renderables) {
     var renderable = node.path.original;
     logRenderable(renderable);
     processNodeForStaticComponentHelper(node);
+    processNodeForViewHelper(node);
   }
 
   function processNodeForStaticComponentHelper(node) {
@@ -37,9 +38,20 @@ function buildDetectorPlugin(renderables) {
     }
   }
 
+  function processNodeForViewHelper(node) {
+    if (node.path.original !== 'view') {
+      return;
+    }
+
+    var viewName = node.params[0];
+    if (viewName.type === 'StringLiteral') {
+      fileInfo.registerViewInvocation(viewName.value);
+    }
+  }
+
   function logRenderable(renderable) {
-    if (renderables.indexOf(renderable) === -1) {
-      renderables.push(renderable);
+    if (fileInfo.renderablesInvoked.indexOf(renderable) === -1) {
+      fileInfo.renderablesInvoked.push(renderable);
     }
   }
 
@@ -68,7 +80,7 @@ var TemplateFileInfo = ClassicFileInfo.extend({
     try {
       compile(fileContents, {
         plugins: {
-          ast: [buildDetectorPlugin(this.renderablesInvoked)]
+          ast: [buildDetectorPlugin(this)]
         }
       });
     } catch (e) {
@@ -80,6 +92,10 @@ var TemplateFileInfo = ClassicFileInfo.extend({
 
       this.registerRenderableUsage(renderable);
     }
+  },
+
+  registerViewInvocation: function(viewName) {
+    this._fileInfoCollection.registerViewInvocation(viewName);
   },
 
   registerRenderableUsage: function(renderable) {

--- a/lib/engines/classic/view-file-info.js
+++ b/lib/engines/classic/view-file-info.js
@@ -1,0 +1,17 @@
+var path = require('path');
+var ClassicFileInfo = require('./classic-file-info');
+
+var ViewFileInfo = ClassicFileInfo.extend({
+  fileInfoType: 'ViewFileInfo',
+
+  repopulate: function() {
+    var viewName = path.join(this.namespace, this.name);
+
+    if (this._fileInfoCollection.viewInvokedInTemplate(viewName)) {
+      this.collectionGroup = 'ui';
+      this.collection = 'views';
+    }
+  }
+});
+
+module.exports = ViewFileInfo;

--- a/lib/index.js
+++ b/lib/index.js
@@ -105,17 +105,23 @@ var Engine = CoreObject.extend({
       }
     }
 
+    // invoke the `repopulate` hook on each file
+    // allowing it to tweak/modify path related
+    // properties after all files have been processed
+    fileInfos.forEach(function(fileInfo) {
+      fileInfo.repopulate();
+    });
+
     // move them all. this is split so that
     // they can all be populated which helps
     // determine the destRelativePath (which is
     // a getter)
-    for (i = 0; i < fileInfos.length; i++) {
-      fileInfo = fileInfos[i];
+    fileInfos.forEach(function(fileInfo) {
       var source = projectRoot + '/' + fileInfo.sourceRelativePath;
       var dest = projectRoot + '/' + fileInfo.destRelativePath;
 
       this._queueMoveFile(source, dest);
-    }
+    }, this);
 
     this._queueRemoveEmptyDirs('app');
     this._queueRemoveEmptyDirs('tests');

--- a/lib/models/file-info-collection.js
+++ b/lib/models/file-info-collection.js
@@ -5,6 +5,7 @@ var FileInfoCollection = CoreObject.extend({
     this._fileInfos = [];
     this._bucketCounts = {};
     this._renderableInvocations = {};
+    this._viewInvocations = {};
   },
 
   add: function(fileInfo) {
@@ -16,6 +17,10 @@ var FileInfoCollection = CoreObject.extend({
     }
 
     this._bucketCounts[bucket]++;
+  },
+
+  registerViewInvocation: function(viewName) {
+    this._viewInvocations[viewName] = true;
   },
 
   registerRenderableInvocation: function(options) {
@@ -43,6 +48,10 @@ var FileInfoCollection = CoreObject.extend({
     }
 
     return null;
+  },
+
+  viewInvokedInTemplate: function(viewName) {
+    return this._viewInvocations[viewName];
   }
 });
 

--- a/lib/models/file-info.js
+++ b/lib/models/file-info.js
@@ -79,6 +79,12 @@ var FileInfo = CoreObject.extend({
 
     this.collection = values.collection;
     this.collectionGroup = values.collectionGroup;
+  },
+
+  repopulate: function() {
+    // by default this is a noop, but in some cases
+    // we may want to update various values once
+    // all files have been processed
   }
 });
 

--- a/lib/utils/calculate-collection-info.js
+++ b/lib/utils/calculate-collection-info.js
@@ -40,6 +40,7 @@ module.exports = function(type) {
     collectionGroup = 'data';
     break;
 
+  case 'view':
   case 'route':
   case 'controller':
   case 'template':

--- a/test/fixtures/classic-view-support/input.js
+++ b/test/fixtures/classic-view-support/input.js
@@ -1,0 +1,13 @@
+module.exports = {
+  'app': {
+    'views': {
+      'foo.js': 'foo view no template invocation',
+      'bar.js': 'bar view with template invocation'
+    },
+    'templates': {
+      'index.hbs': '{{view "bar"}}',
+      'foo.hbs': 'foo template'
+    }
+  },
+  'tests': {}
+};

--- a/test/fixtures/classic-view-support/output.js
+++ b/test/fixtures/classic-view-support/output.js
@@ -1,0 +1,18 @@
+module.exports = {
+  'src': {
+    'ui': {
+      'views': {
+        'bar.js': 'bar view with template invocation'
+      },
+      'routes': {
+        'index': {
+          'template.hbs': '{{view "bar"}}'
+        },
+        'foo': {
+          'view.js': 'foo view no template invocation',
+          'template.hbs': 'foo template'
+        }
+      }
+    }
+  }
+};


### PR DESCRIPTION
Views that are not invoked via templates are put in `src/ui/routes` and those that are template invoked (via string literal view name) are put into `src/ui/views`.

Also adds `repopulate` hook to allow file infos to do work to detect usage and tweak resulting collection/name/etc.

Partially addresses #18.