### PR TITLE
Remove duplicated namespace for components nested using routes namespace

### DIFF
--- a/lib/engines/classic/component-template-file-info.js
+++ b/lib/engines/classic/component-template-file-info.js
@@ -12,7 +12,7 @@ var ComponentTemplateFileInfo = TemplateFileInfo.extend({
   populateName: function() {
     this._super.populateName.apply(this, arguments);
 
-    var namespace = this.namespace.replace(/^components/, '');
+    var namespace = this.namespace.replace(/^components\/?/, '');
 
     this.namespace = namespace;
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -26,6 +26,7 @@ var Engine = CoreObject.extend({
 
     this._promise = null;
     this._fileInfoCollection = new FileInfoCollection();
+    this._fileInfos = [];
   },
 
   _queueMoveFile: function(source, dest) {
@@ -90,33 +91,22 @@ var Engine = CoreObject.extend({
     );
 
     var projectRoot = this.projectRoot;
-    var fileInfos = [];
-    var fileInfo, i;
+    var i;
 
     // build all the fileInfo objects
     for (i = 0; i < inputFiles.length; i++) {
       var relativePath = inputFiles[i];
 
-      fileInfo = this.fileInfoFor(relativePath);
-
-      // not all files in `tests` return a FileInfo
-      if (fileInfo) {
-        fileInfos.push(fileInfo);
-      }
+      this.fileInfoFor(relativePath);
     }
 
-    // invoke the `repopulate` hook on each file
-    // allowing it to tweak/modify path related
-    // properties after all files have been processed
-    fileInfos.forEach(function(fileInfo) {
-      fileInfo.repopulate();
-    });
+    this.finalizeFileDiscovery();
 
     // move them all. this is split so that
     // they can all be populated which helps
     // determine the destRelativePath (which is
     // a getter)
-    fileInfos.forEach(function(fileInfo) {
+    this._fileInfos.forEach(function(fileInfo) {
       var source = projectRoot + '/' + fileInfo.sourceRelativePath;
       var dest = projectRoot + '/' + fileInfo.destRelativePath;
 
@@ -130,9 +120,25 @@ var Engine = CoreObject.extend({
   },
 
   fileInfoFor: function(path) {
-    return this.engine.buildFor(path, {
+    var fileInfo = this.engine.buildFor(path, {
       projectRoot: this.projectRoot,
       _fileInfoCollection: this._fileInfoCollection
+    });
+
+    // not all files return a FileInfo
+    if (fileInfo) {
+      this._fileInfos.push(fileInfo);
+    }
+
+    return fileInfo;
+  },
+
+  finalizeFileDiscovery: function() {
+    // invoke the `repopulate` hook on each file
+    // allowing it to tweak/modify path related
+    // properties after all files have been processed
+    this._fileInfos.forEach(function(fileInfo) {
+      fileInfo.repopulate();
     });
   }
 });

--- a/lib/models/file-info.js
+++ b/lib/models/file-info.js
@@ -82,9 +82,21 @@ var FileInfo = CoreObject.extend({
   },
 
   repopulate: function() {
-    // by default this is a noop, but in some cases
-    // we may want to update various values once
-    // all files have been processed
+    var inElementsCollection = this.collection === 'elements';
+    var renderableName = path.join(this.namespace, this.name);
+
+    if (inElementsCollection) {
+      var privateRenderableInvoker = this._fileInfoCollection.detectPrivateRenderableInvoker(renderableName);
+
+      this._privateRenderableInvoker = privateRenderableInvoker;
+
+      if (privateRenderableInvoker) {
+        var invokerPath = path.join(privateRenderableInvoker.namespace, privateRenderableInvoker.name);
+        if (invokerPath === this.namespace) {
+          this.namespace = '';
+        }
+      }
+    }
   },
 
   shouldUseDotFormNaming: function() {
@@ -123,23 +135,16 @@ Object.defineProperty(FileInfo.prototype, 'destRelativePath', {
       this.collection
     );
 
-    var inElementsCollection = this.collection === 'elements';
-    var destRelativePath;
+    if (this._privateRenderableInvoker) {
+      var invokerLocation = path.dirname(this._privateRenderableInvoker.destRelativePath);
+      var privateCollection = invokerLocation.indexOf('-elements') > -1 ? '' : '-elements';
 
-    if (inElementsCollection) {
-      var renderableName = path.join(this.namespace, this.name);
-      var privateRenderableInvoker = this._fileInfoCollection.detectPrivateRenderableInvoker(renderableName);
-
-      if (privateRenderableInvoker) {
-        var invokerLocation = path.dirname(privateRenderableInvoker.destRelativePath);
-        var privateCollection = invokerLocation.indexOf('-elements') > -1 ? '' : '-elements';
-
-        baseRelativePath = path.join(
-          invokerLocation,
-          privateCollection
-        );
-      }
+      baseRelativePath = path.join(
+        invokerLocation,
+        privateCollection
+      );
     }
+    var destRelativePath;
 
     if (this.shouldUseDotFormNaming()) {
       destRelativePath = path.join(

--- a/test/engines/classic/template-file-info-test.js
+++ b/test/engines/classic/template-file-info-test.js
@@ -44,6 +44,7 @@ describe('template-file-info', function() {
     confirmDetectsRenderables('<div>{{#foo-bar}}{{huz-zah blah="lolol"}}{{/foo-bar}}</div>', ['foo-bar', 'huz-zah']);
     confirmDetectsRenderables('{{yield (hash foo=(build-thing) bar=(component "bar-baz"))}}', ['yield', 'hash', 'build-thing', 'component', 'bar-baz']);
     confirmDetectsRenderables('{{component "foo-bar"}}', ['component', 'foo-bar']);
+    confirmDetectsRenderables('{{foo/bar/baz/x-blah}}', ['foo/bar/baz/x-blah']);
 
     // helpers
     confirmDetectsRenderables('{{t "some thing"}}', ['t']);

--- a/test/fixtures/classic-nested-component-invocation/input.js
+++ b/test/fixtures/classic-nested-component-invocation/input.js
@@ -1,0 +1,20 @@
+module.exports = {
+  app: {
+    templates: {
+      components: {
+        posts: {
+          edit: {
+            'x-button.hbs': 'x-button template'
+          }
+        }
+      },
+      posts: {
+        'edit.hbs': '{{posts/edit/x-button}}'
+      }
+    }
+  },
+
+  tests: {
+
+  }
+};

--- a/test/fixtures/classic-nested-component-invocation/output.js
+++ b/test/fixtures/classic-nested-component-invocation/output.js
@@ -1,0 +1,18 @@
+module.exports = {
+  src: {
+    ui: {
+      routes: {
+        posts: {
+          edit: {
+            '-elements': {
+              'x-button': {
+                'template.hbs': 'x-button template'
+              }
+            },
+            'template.hbs': '{{posts/edit/x-button}}'
+          }
+        }
+      }
+    }
+  }
+};

--- a/test/models/file-info-test.js
+++ b/test/models/file-info-test.js
@@ -15,11 +15,15 @@ describe('file-info model', function() {
     it('can calculate a destRelativePath where type is the same as collection', function() {
       var file = engine.fileInfoFor('app/routes/foo-bar.js');
 
+      engine.finalizeFileDiscovery();
+
       assert(file.destRelativePath === 'src/ui/routes/foo-bar.js');
     });
 
     it('can calculate a destRelativePath where type is not the same as collection', function() {
       var file = engine.fileInfoFor('app/adapters/foo.js');
+
+      engine.finalizeFileDiscovery();
 
       assert(file.destRelativePath === 'src/data/models/foo/adapter.js');
     });
@@ -27,12 +31,16 @@ describe('file-info model', function() {
     it('uses <name>.<ext> instead of <name>/<type>.<ext> when only a single item that is the default type is present', function() {
       var file = engine.fileInfoFor('app/models/foo.js');
 
+      engine.finalizeFileDiscovery();
+
       assert(file.destRelativePath === 'src/data/models/foo.js');
     });
 
     it('uses <name>/<ext> instead of <name>.<type>.<ext> when multiple items exist for the bucket', function() {
       var model = engine.fileInfoFor('app/models/foo.js');
       var adapter = engine.fileInfoFor('app/adapters/foo.js');
+
+      engine.finalizeFileDiscovery();
 
       assert(model.destRelativePath === 'src/data/models/foo/model.js');
       assert(adapter.destRelativePath === 'src/data/models/foo/adapter.js');
@@ -42,6 +50,8 @@ describe('file-info model', function() {
       var model = engine.fileInfoFor('app/models/foo.js');
       var test = engine.fileInfoFor('tests/integration/models/foo-test.js');
 
+      engine.finalizeFileDiscovery();
+
       assert(model.destRelativePath === 'src/data/models/foo/model.js');
       assert(test.destRelativePath === 'src/data/models/foo/model-integration-test.js');
     });
@@ -49,6 +59,8 @@ describe('file-info model', function() {
     it('uses <name>/<ext> instead of <name>.<type>.<ext> when a mixin and a test exist', function() {
       var model = engine.fileInfoFor('app/mixins/foo.js');
       var test = engine.fileInfoFor('tests/unit/mixins/foo-test.js');
+
+      engine.finalizeFileDiscovery();
 
       assert(model.destRelativePath === 'src/utils/mixins/foo/mixin.js');
       assert(test.destRelativePath === 'src/utils/mixins/foo/mixin-unit-test.js');
@@ -58,6 +70,8 @@ describe('file-info model', function() {
       var model = engine.fileInfoFor('app/services/foo.js');
       var test = engine.fileInfoFor('tests/integration/services/foo-test.js');
 
+      engine.finalizeFileDiscovery();
+
       assert(model.destRelativePath === 'src/services/foo/service.js');
       assert(test.destRelativePath === 'src/services/foo/service-integration-test.js');
     });
@@ -65,6 +79,8 @@ describe('file-info model', function() {
     it('uses <name>/<ext> instead of <name>.<ext> when a util and a test exist', function() {
       var util = engine.fileInfoFor('app/utils/foo.js');
       var test = engine.fileInfoFor('tests/unit/utils/foo-test.js');
+
+      engine.finalizeFileDiscovery();
 
       assert(util.destRelativePath === 'src/utils/foo/util.js');
       assert(test.destRelativePath === 'src/utils/foo/util-unit-test.js');
@@ -77,6 +93,8 @@ describe('file-info model', function() {
 
         routeTemplate.registerRenderableUsage('foo-bar');
 
+        engine.finalizeFileDiscovery();
+
         assert(componentTemplate.destRelativePath === 'src/ui/routes/posts/index/-elements/foo-bar/template.hbs');
       });
 
@@ -85,6 +103,8 @@ describe('file-info model', function() {
         var component = engine.fileInfoFor('app/components/foo-bar.js');
 
         routeTemplate.registerRenderableUsage('foo-bar');
+
+        engine.finalizeFileDiscovery();
 
         assert(component.destRelativePath === 'src/ui/routes/posts/index/-elements/foo-bar/component.js');
       });
@@ -95,6 +115,8 @@ describe('file-info model', function() {
 
         routeTemplate.registerRenderableUsage('bar');
 
+        engine.finalizeFileDiscovery();
+
         assert(helper.destRelativePath === 'src/ui/routes/posts/index/-elements/bar.js');
       });
 
@@ -104,6 +126,8 @@ describe('file-info model', function() {
         var helperTest = engine.fileInfoFor('tests/integration/helpers/bar-test.js');
 
         routeTemplate.registerRenderableUsage('bar');
+
+        engine.finalizeFileDiscovery();
 
         assert(helper.destRelativePath === 'src/ui/routes/posts/index/-elements/bar/helper.js');
         assert(helperTest.destRelativePath === 'src/ui/routes/posts/index/-elements/bar/helper-integration-test.js');
@@ -116,8 +140,23 @@ describe('file-info model', function() {
 
         routeTemplate.registerRenderableUsage('foo-bar');
 
+        engine.finalizeFileDiscovery();
+
         assert(component.destRelativePath === 'src/ui/routes/posts/index/-elements/foo-bar/component.js');
         assert(componentTemplate.destRelativePath === 'src/ui/routes/posts/index/-elements/foo-bar/template.hbs');
+      });
+
+      it('detecting private / single use components with slashes in component invocation', function() {
+        var routeTemplate = engine.fileInfoFor('app/templates/posts/post.hbs');
+        var component = engine.fileInfoFor('app/components/posts/post/foo-bar.js');
+        var componentTemplate = engine.fileInfoFor('app/templates/components/posts/post/foo-bar.hbs');
+
+        routeTemplate.registerRenderableUsage('posts/post/foo-bar');
+
+        engine.finalizeFileDiscovery();
+
+        assert(component.destRelativePath === 'src/ui/routes/posts/post/-elements/foo-bar/component.js');
+        assert(componentTemplate.destRelativePath === 'src/ui/routes/posts/post/-elements/foo-bar/template.hbs');
       });
 
       it('detecting private / single use components within other private/single use components', function() {
@@ -129,6 +168,8 @@ describe('file-info model', function() {
 
         routeTemplate.registerRenderableUsage('foo-bar');
         fooBarComponentTemplate.registerRenderableUsage('derp-herk');
+
+        engine.finalizeFileDiscovery();
 
         assert(fooBarComponent.destRelativePath === 'src/ui/routes/posts/index/-elements/foo-bar/component.js');
         assert(fooBarComponentTemplate.destRelativePath === 'src/ui/routes/posts/index/-elements/foo-bar/template.hbs');


### PR DESCRIPTION
For example, if the `post/edit` route contains the following template:

```hbs
{{! app/templates/post/edit.hbs }}

{{post/edit/post-edit-form}}
```

When we localize the `post/edit/post-edit-form` component, we also would like to remove the `post/edit` namespace prefix (since it would be duplicated).

Before this change, the `post-edit-form` would be moved to:

```
src/ui/routes/post/edit/-elements/post/edit/post-edit-form/{component.js,template.hbs}
```

After this change, the `post-edit-form` would be moved to:

```
src/ui/routes/post/edit/-elements/post-edit-form/{component.js,template.hbs}
```

---

Future work here would be to rewrite the template to use the correct invocation.