### PR TITLE
Make sure table width is integer

### DIFF
--- a/lib/models/logger.js
+++ b/lib/models/logger.js
@@ -18,9 +18,10 @@ var Logger = CoreObject.extend({
 
   flush: function() {
     var maxWidth = process.stdout.columns - 4;
+    var halfWidth = Math.floor(maxWidth / 2);
     var table = new Table({
       head: ['Source', 'Destination'],
-      colWidths: [maxWidth / 2, maxWidth / 2]
+      colWidths: [halfWidth, halfWidth]
     });
 
 


### PR DESCRIPTION
- In some environments, and depending on how the console window is resized,
maxWidth can be an odd number. This makes maxWidth / 2 a decimal and cli-table2
fails with `RangeError: Invalid array length`.
- Fixes #40