### PR TITLE
Fix `Overriding init` deprecations

### DIFF
--- a/lib/models/file-info-collection.js
+++ b/lib/models/file-info-collection.js
@@ -2,6 +2,8 @@ var CoreObject = require('core-object');
 
 var FileInfoCollection = CoreObject.extend({
   init: function() {
+    this._super.init && this._super.init.apply(this, arguments);
+
     this._fileInfos = [];
     this._bucketCounts = {};
     this._renderableInvocations = {};

--- a/lib/models/file-info.js
+++ b/lib/models/file-info.js
@@ -10,6 +10,8 @@ var FileInfo = CoreObject.extend({
   type: 'FileInfo',
 
   init: function(_options) {
+    this._super.init && this._super.init.apply(this, arguments);
+
     var options = _options || {};
     this.options = options;
     this.projectRoot = options.projectRoot;

--- a/lib/models/logger.js
+++ b/lib/models/logger.js
@@ -5,6 +5,8 @@ var Table = require('cli-table2');
 
 var Logger = CoreObject.extend({
   init: function() {
+    this._super.init && this._super.init.apply(this, arguments);
+
     this._movedFiles = {};
     this._renamedRenderables = [];
   },


### PR DESCRIPTION
Those are appearing when running the tests or the tool
```
DEPRECATION: Overriding init without calling this._super is deprecated. Please call `this._super.init && this._super.init.apply(this, arguments);` addon: `undefined`
    at Object.<anonymous> (/home/andyhot/projects/js/ember-module-migrator/lib/models/logger.js:6:25)
DEPRECATION: Overriding init without calling this._super is deprecated. Please call this._super(), addon: `undefined`
    at Object.<anonymous> (/home/andyhot/projects/js/ember-module-migrator/lib/models/file-info.js:9:27)
DEPRECATION: Overriding init without calling this._super is deprecated. Please call `this._super.init && this._super.init.apply(this, arguments);` addon: `undefined`
    at Object.<anonymous> (/home/andyhot/projects/js/ember-module-migrator/lib/models/file-info-collection.js:3:37)
```