### PR TITLE
Fix travis build by guarding against zero process.stdout.columns

### DIFF
--- a/lib/models/logger.js
+++ b/lib/models/logger.js
@@ -19,7 +19,9 @@ var Logger = CoreObject.extend({
   },
 
   flush: function() {
-    var maxWidth = process.stdout.columns - 4;
+    // guard against environments such as travis that report zero columns
+    var columns = process.stdout.columns || 80;
+    var maxWidth = columns - 4;
     var halfWidth = Math.floor(maxWidth / 2);
     var table = new Table({
       head: ['Source', 'Destination'],


### PR DESCRIPTION
Logger-test is failing on travis due to it reporting process.stdout.columns as 0,
making the report table display ellipsis instead of the expected data.

This PR defaults columns to 80 in such cases