### PR TITLE
Update fixture contents to be valid js

### DIFF
--- a/test/fixtures/classic-acceptance/input.js
+++ b/test/fixtures/classic-acceptance/input.js
@@ -1,71 +1,71 @@
 module.exports = {
   'app': {
-    'app.js': 'app.js',
-    'router.js': 'router.js',
+    'app.js': '"app.js"',
+    'router.js': '"router.js"',
     'index.html': 'index.html contents',
     'components': {
-      'foo-bar.js': 'foo-bar component',
+      'foo-bar.js': '"foo-bar component"',
       'baz-derp': {
-        'component.js': 'baz-derp component',
+        'component.js': '"baz-derp component"',
         'template.hbs': 'baz-derp template'
       },
       'post-display': {
-        'component.js': 'post-display component',
+        'component.js': '"post-display component"',
         'template.hbs': 'post-display component template\n{{post-footer}}'
       },
       'post-footer': {
-        'component.js': 'post-footer component',
+        'component.js': '"post-footer component"',
         'template.hbs': 'post-footer component template'
       }
     },
     'helpers': {
-      'i18n.js': 'i18n helper',
-      'blerg.js': 'blerg helper',
-      'main-greeting-text.js': 'main-greeting-text helper',
-      'show-default-title.js': 'show-default-title helper'
+      'i18n.js': '"i18n helper"',
+      'blerg.js': '"blerg helper"',
+      'main-greeting-text.js': '"main-greeting-text helper"',
+      'show-default-title.js': '"show-default-title helper"'
     },
     'routes': {
-      'index.js': 'index route',
+      'index.js': '"index route"',
       'posts': {
-        'index.js': 'posts/index route',
+        'index.js': '"posts/index route"',
         'post': {
-          'index.js': 'posts/post/index route',
-          'edit.js': 'posts/post/edit route'
+          'index.js': '"posts/post/index route"',
+          'edit.js': '"posts/post/edit route"'
         },
-        'new.js': 'posts/new route'
+        'new.js': '"posts/new route"'
       }
     },
     'adapters': {
-      'application.js': 'application adapter',
-      'post.js': 'post adapter',
-      'comment.js': 'comment adapter'
+      'application.js': '"application adapter"',
+      'post.js': '"post adapter"',
+      'comment.js': '"comment adapter"'
     },
     'serializers': {
-      'application.js': 'application serializer',
-      'post.js': 'post serializer',
-      'comment.js': 'comment serializer'
+      'application.js': '"application serializer"',
+      'post.js': '"post serializer"',
+      'comment.js': '"comment serializer"'
     },
     'models': {
-      'post.js': 'post model',
-      'comment.js': 'comment model',
-      'tag.js': 'tag model'
+      'post.js': '"post model"',
+      'comment.js': '"comment model"',
+      'tag.js': '"tag model"'
     },
     'initializers': {
-      'blah.js': 'blah initializer',
-      'derp.js': 'derp initializer'
+      'blah.js': '"blah initializer"',
+      'derp.js': '"derp initializer"'
     },
     'instance-initializers': {
-      'blammo.js': 'blammo instance initializer'
+      'blammo.js': '"blammo instance initializer"'
     },
     'controllers': {
-      'index.js': 'index controller',
+      'index.js': '"index controller"',
       'posts': {
-        'index.js': 'posts/index controller',
+        'index.js': '"posts/index controller"',
         'post': {
-          'index.js': 'posts/post/index controller',
-          'edit.js': 'posts/post/edit controller'
+          'index.js': '"posts/post/index controller"',
+          'edit.js': '"posts/post/edit controller"'
         },
-        'new.js': 'posts/new controller'
+        'new.js': '"posts/new controller"'
       }
     },
     'templates': {
@@ -84,51 +84,51 @@ module.exports = {
       }
     },
     'transforms': {
-      'date.js': 'custom date transform'
+      'date.js': '"custom date transform"'
     },
     'mixins': {
-      'foo.js': 'foo mixin'
+      'foo.js': '"foo mixin"'
     },
     'services': {
-      'ajax.js': 'ajax service'
+      'ajax.js': '"ajax service"'
     },
     'validators': {
-      'blahzorz.js': 'blahzorz validator'
+      'blahzorz.js': '"blahzorz validator"'
     }
   },
 
   'tests': {
     'acceptance': {
-      'post-test.js': 'post acceptance test'
+      'post-test.js': '"post acceptance test"'
     },
     'unit': {
       'mixins': {
-        'foo-test.js': 'foo mixin unit test'
+        'foo-test.js': '"foo mixin unit test"'
       },
       'service': {
-        'ajax-test.js': 'ajax service unit test'
+        'ajax-test.js': '"ajax service unit test"'
       },
       'routes': {
         'posts': {
-          'index-test.js': 'posts/index unit test'
+          'index-test.js': '"posts/index unit test"'
         }
       },
       'validators': {
-        'blahzorz-test.js': 'blahzorz validator test'
+        'blahzorz-test.js': '"blahzorz validator test"'
       }
     },
     'integration': {
       'routes': {
         'posts': {
-          'index-test.js': 'posts/index integration test'
+          'index-test.js': '"posts/index integration test"'
         }
       },
       'components': {
-        'post-display-test.js': 'post-display component integration test',
-        'post-footer-test.js': 'post-footer integration test'
+        'post-display-test.js': '"post-display component integration test"',
+        'post-footer-test.js': '"post-footer integration test"'
       },
       'helpers': {
-        'show-default-title-test.js': 'show-default-title helper integration test'
+        'show-default-title-test.js': '"show-default-title helper integration test"'
       }
     }
   }

--- a/test/fixtures/classic-acceptance/output.js
+++ b/test/fixtures/classic-acceptance/output.js
@@ -1,46 +1,46 @@
 module.exports = {
   'src': {
-    'main.js': 'app.js',
-    'router.js': 'router.js',
+    'main.js': '"app.js"',
+    'router.js': '"router.js"',
     'init': {
       'initializers': {
-        'blah.js': 'blah initializer',
-        'derp.js': 'derp initializer'
+        'blah.js': '"blah initializer"',
+        'derp.js': '"derp initializer"'
       },
       'instance-initializers': {
-        'blammo.js': 'blammo instance initializer'
+        'blammo.js': '"blammo instance initializer"'
       }
     },
     'ui': {
       'index.html': 'index.html contents',
       'components': {
         'foo-bar': {
-          'component.js': 'foo-bar component',
+          'component.js': '"foo-bar component"',
           'template.hbs': 'foo-bar component template'
         },
         'baz-derp': {
-          'component.js': 'baz-derp component',
+          'component.js': '"baz-derp component"',
           'template.hbs': 'baz-derp template'
         },
-        'i18n.js': 'i18n helper',
-        'blerg.js': 'blerg helper'
+        'i18n.js': '"i18n helper"',
+        'blerg.js': '"blerg helper"'
       },
       'routes': {
         'index': {
           '-components': {
-            'main-greeting-text.js': 'main-greeting-text helper'
+            'main-greeting-text.js': '"main-greeting-text helper"'
           },
-          'controller.js': 'index controller',
-          'route.js': 'index route',
+          'controller.js': '"index controller"',
+          'route.js': '"index route"',
           'template.hbs': 'index route template {{main-greeting-text}}'
         },
         'posts': {
           'index': {
-            'controller.js': 'posts/index controller',
-            'route.js': 'posts/index route',
+            'controller.js': '"posts/index controller"',
+            'route.js': '"posts/index route"',
             'template.hbs': 'posts/index route template',
-            'route-unit-test.js': 'posts/index unit test',
-            'route-integration-test.js': 'posts/index integration test'
+            'route-unit-test.js': '"posts/index unit test"',
+            'route-integration-test.js': '"posts/index integration test"'
           },
           'show': {
             'template.hbs': 'posts/post/show route template'
@@ -50,34 +50,34 @@ module.exports = {
               '-components': {
                 'post-display': {
                   'post-footer': {
-                    'component.js': 'post-footer component',
+                    'component.js': '"post-footer component"',
                     'template.hbs': 'post-footer component template',
-                    'component-integration-test.js': 'post-footer integration test'
+                    'component-integration-test.js': '"post-footer integration test"'
                   },
-                  'component.js': 'post-display component',
+                  'component.js': '"post-display component"',
                   'template.hbs': 'post-display component template\n{{post-footer}}',
-                  'component-integration-test.js': 'post-display component integration test'
+                  'component-integration-test.js': '"post-display component integration test"'
                 }
               },
-              'controller.js': 'posts/post/index controller',
-              'route.js': 'posts/post/index route',
+              'controller.js': '"posts/post/index controller"',
+              'route.js': '"posts/post/index route"',
               'template.hbs': 'posts/post/index route template\n{{post-display}}'
             },
             'edit': {
-              'controller.js': 'posts/post/edit controller',
-              'route.js': 'posts/post/edit route',
+              'controller.js': '"posts/post/edit controller"',
+              'route.js': '"posts/post/edit route"',
               'template.hbs': 'posts/post/edit route template'
             }
           },
           'new': {
             '-components': {
               'show-default-title': {
-                'helper.js': 'show-default-title helper',
-                'helper-integration-test.js': 'show-default-title helper integration test'
+                'helper.js': '"show-default-title helper"',
+                'helper-integration-test.js': '"show-default-title helper integration test"'
               }
             },
-            'controller.js': 'posts/new controller',
-            'route.js': 'posts/new route',
+            'controller.js': '"posts/new controller"',
+            'route.js': '"posts/new route"',
             'template.hbs': 'posts/new route template {{show-default-title}}'
           }
         }
@@ -86,49 +86,49 @@ module.exports = {
     'data': {
       'models': {
         'application': {
-          'adapter.js': 'application adapter',
-          'serializer.js': 'application serializer'
+          'adapter.js': '"application adapter"',
+          'serializer.js': '"application serializer"'
         },
         'post': {
-          'adapter.js': 'post adapter',
-          'serializer.js': 'post serializer',
-          'model.js': 'post model'
+          'adapter.js': '"post adapter"',
+          'serializer.js': '"post serializer"',
+          'model.js': '"post model"'
         },
         'comment': {
-          'adapter.js': 'comment adapter',
-          'serializer.js': 'comment serializer',
-          'model.js': 'comment model'
+          'adapter.js': '"comment adapter"',
+          'serializer.js': '"comment serializer"',
+          'model.js': '"comment model"'
         },
-        'tag.js': 'tag model'
+        'tag.js': '"tag model"'
       },
       transforms: {
-        'date.js': 'custom date transform'
+        'date.js': '"custom date transform"'
       }
     },
     'services': {
       'ajax': {
-        'service-unit-test.js': 'ajax service unit test',
-        'service.js': 'ajax service'
+        'service-unit-test.js': '"ajax service unit test"',
+        'service.js': '"ajax service"'
       }
     },
     'utils': {
       'mixins': {
         'foo': {
-          'mixin.js': 'foo mixin',
-          'mixin-unit-test.js': 'foo mixin unit test'
+          'mixin.js': '"foo mixin"',
+          'mixin-unit-test.js': '"foo mixin unit test"'
         }
       }
     },
     'validators': {
       'blahzorz': {
-        'validator.js': 'blahzorz validator',
-        'validator-unit-test.js': 'blahzorz validator test'
+        'validator.js': '"blahzorz validator"',
+        'validator-unit-test.js': '"blahzorz validator test"'
       }
     }
   },
   'tests': {
     'acceptance': {
-      'post-test.js': 'post acceptance test'
+      'post-test.js': '"post acceptance test"'
     }
   }
 };

--- a/test/fixtures/classic-named-exports/input.js
+++ b/test/fixtures/classic-named-exports/input.js
@@ -12,7 +12,7 @@ module.exports = {
   tests: {
     integration: {
       helpers: {
-        'capitalize-test.js': 'capitalize helper test'
+        'capitalize-test.js': '"capitalize helper test"'
       }
     }
   }

--- a/test/fixtures/classic-named-exports/output.js
+++ b/test/fixtures/classic-named-exports/output.js
@@ -7,7 +7,7 @@ module.exports = {
         'titleize.js': 'export const helper = helper(function() { });',
         'capitalize': {
           'helper.js': 'export default helper(function() { });',
-          'helper-integration-test.js': 'capitalize helper test'
+          'helper-integration-test.js': '"capitalize helper test"'
         }
       }
     }

--- a/test/fixtures/classic-private-components/input.js
+++ b/test/fixtures/classic-private-components/input.js
@@ -15,7 +15,7 @@ module.exports = {
   tests: {
     integration: {
       components: {
-        'x-bar-test.js': 'x-bar component test'
+        'x-bar-test.js': '"x-bar component test"'
       }
     }
   }

--- a/test/fixtures/classic-private-components/output.js
+++ b/test/fixtures/classic-private-components/output.js
@@ -6,7 +6,7 @@ module.exports = {
           'template.hbs': 'x-foo template: {{x-bar}}',
           'x-bar': {
             'template.hbs': 'x-bar template',
-            'component-integration-test.js': 'x-bar component test'
+            'component-integration-test.js': '"x-bar component test"'
           }
         }
       },

--- a/test/fixtures/classic-view-support/input.js
+++ b/test/fixtures/classic-view-support/input.js
@@ -1,8 +1,8 @@
 module.exports = {
   'app': {
     'views': {
-      'foo.js': 'foo view no template invocation',
-      'bar.js': 'bar view with template invocation'
+      'foo.js': '"foo view no template invocation"',
+      'bar.js': '"bar view with template invocation"'
     },
     'templates': {
       'index.hbs': '{{view "bar"}}',

--- a/test/fixtures/classic-view-support/output.js
+++ b/test/fixtures/classic-view-support/output.js
@@ -2,14 +2,14 @@ module.exports = {
   'src': {
     'ui': {
       'views': {
-        'bar.js': 'bar view with template invocation'
+        'bar.js': '"bar view with template invocation"'
       },
       'routes': {
         'index': {
           'template.hbs': '{{view "bar"}}'
         },
         'foo': {
-          'view.js': 'foo view no template invocation',
+          'view.js': '"foo view no template invocation"',
           'template.hbs': 'foo template'
         }
       }

--- a/test/fixtures/directory-cleanup/input.js
+++ b/test/fixtures/directory-cleanup/input.js
@@ -2,7 +2,7 @@ module.exports = {
   'app': {
     'routes': {
       '.gitkeep': '',
-      'post.js': 'post route'
+      'post.js': '"post route"'
     },
     'templates': {
       '.gitkeep': '',

--- a/test/fixtures/directory-cleanup/output.js
+++ b/test/fixtures/directory-cleanup/output.js
@@ -3,7 +3,7 @@ module.exports = {
     'ui': {
       'routes': {
         'post': {
-          'route.js': 'post route',
+          'route.js': '"post route"',
           'template.hbs': 'post route template'
         }
       }


### PR DESCRIPTION
- This will be essential to minimize warnings in tests once we
use jscodeshift (which parses js and thus fails in those cases)
- I basically turned invalid js content such as `foo-bar component` into string expressions `"foo-bar component"`