### PR TITLE
Fix config import rewriting to only affect the root config

### DIFF
--- a/lib/transforms/import-declarations.js
+++ b/lib/transforms/import-declarations.js
@@ -22,7 +22,7 @@ function transformer(file, api) {
         var sourceRelativePath = file.fileInfo.sourceRelativePath;
 
         if (sourceRelativePath.startsWith('tests/')) {
-          importPath = path_utils.makeAbsolute(appName + '/app/' + sourceRelativePath, importPath);
+          importPath = path_utils.makeAbsolute('app/' + sourceRelativePath, importPath, appName);
 
           // see if we stayed within tests
           var inTestsPrefix = appName + '/app/tests/';
@@ -30,7 +30,7 @@ function transformer(file, api) {
             importPath = appName + '/tests/' + importPath.substring(inTestsPrefix.length);
           }
         } else {
-          importPath = path_utils.makeAbsolute(appName + '/' + sourceRelativePath, importPath);
+          importPath = path_utils.makeAbsolute(sourceRelativePath, importPath, appName);
         }
       } else {
         // check if import path starts with appName and add /app

--- a/lib/utils/path.js
+++ b/lib/utils/path.js
@@ -12,12 +12,18 @@ function makeRelative(from, to) {
   return path;
 }
 
-function makeAbsolute(base, path) {
-  var isConfigPath = path.indexOf('/config/') > 0;
-  var baseDir = p.dirname('/' + base);
-  if (isConfigPath) {
-    baseDir += '/..';
+function makeAbsolute(base, path, appName) {
+  var baseDir = p.dirname(`/${appName}/${base}`);
+
+  // check if path goes over the root config folder and adjust base
+  var configIndex = path.indexOf('/config/');
+  if (configIndex >= 0) {
+    var configPath = p.resolve(baseDir, path.substring(0, configIndex) + '/config').substring(1);
+    if (configPath == `${appName}/app/config`) {
+      baseDir += '/..';
+    }
   }
+
   return p.resolve(baseDir, path).substring(1);
 }
 

--- a/test/fixtures/config/input.js
+++ b/test/fixtures/config/input.js
@@ -2,8 +2,11 @@ module.exports = {
   app: {
     'app.js': 'import config from "./config/environment";',
     utils: {
-      'first.js': 'import config from "my-app/config/environment";',
-      'second.js': 'import config from "../config/environment";'
+      'first.js': 'import ConfigUtils from "./config/third";',
+      'second.js': 'import config from "../config/environment";',
+      config: {
+        'third.js': 'import config from "../../config/environment";',
+      }
     }
   },
   config: {
@@ -13,7 +16,10 @@ module.exports = {
     unit: {
       utils: {
         'first-test.js': 'import config from "../../../config/environment";',
-        'second-test.js': 'import config from "my-app/config/environment";'
+        'second-test.js': 'import config from "my-app/config/environment";',
+        config: {
+          'third-test.js': 'import config from "my-app/config/environment";'
+        }
       }
     }
   }

--- a/test/fixtures/config/output.js
+++ b/test/fixtures/config/output.js
@@ -3,12 +3,18 @@ module.exports = {
     'main.js': 'import config from "../config/environment";',
     utils: {
       first: {
-        'util.js': 'import config from "my-app/config/environment";',
+        'util.js': 'import ConfigUtils from "../config/third/util";',
         'util-unit-test.js': 'import config from "../../../config/environment";'
       },
       second: {
         'util.js': 'import config from "../../../config/environment";',
         'util-unit-test.js': 'import config from "my-app/config/environment";'
+      },
+      config: {
+        third: {
+          'util-unit-test.js': 'import config from "my-app/config/environment";',
+          'util.js': 'import config from "../../../../config/environment";'
+        }
       }
     }
   },


### PR DESCRIPTION
The previous config related PR had a bug when detecting the config folder. It would rewrite imports to files if they happened to exist in a path that contained `/config/`

This PR includes a fixture that demonstrates this and the fix.

I don't like how makeAbsolute() in lib/utils/path.js and transformer() in lib/transforms/import-declarations.js have become complex, so I'm planning to address that in a following PR.

Since we released a new version today, i think this fix should be included asap