### PR TITLE
Fix eslint

### DIFF
--- a/lib/engines/classic/index.js
+++ b/lib/engines/classic/index.js
@@ -71,7 +71,7 @@ module.exports = {
         options.type = testSubjectType + '-' + testType + '-test';
 
         return new TestFileInfo(options);
-      } else if (testType !== 'acceptance') {
+      } else if (testType !== 'acceptance' && pathParts[2]) {
         options.type = testType;
         options.base = 'tests';
         return new ClassicFileInfo(options);

--- a/test/fixtures/test-helpers/input.js
+++ b/test/fixtures/test-helpers/input.js
@@ -7,6 +7,8 @@ module.exports = {
     'environment.js': '"ENV"'
   },
   tests: {
+    '.eslint.js': '{}',
+    'test-helper.js': '{}',
     helpers: {
       'resolver.js': 'import Resolver from "../../resolver";',
       'start-app.js': 'import App from "../../app";'

--- a/test/fixtures/test-helpers/output.js
+++ b/test/fixtures/test-helpers/output.js
@@ -7,6 +7,8 @@ module.exports = {
     'environment.js': '"ENV"'
   },
   tests: {
+    '.eslint.js': '{}',
+    'test-helper.js': '{}',
     'helpers': {
       'resolver.js': 'import Resolver from "../../src/resolver";',
       'start-app.js': 'import App from "../../src/main";'


### PR DESCRIPTION
`tests/.eslint.js` files are incorrectly treated like a helper file.