### PR TITLE
Migrate pods with undefined podModulePrefix

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -144,7 +144,7 @@ var Engine = CoreObject.extend({
     var fileInfo = this.engine.buildFor(path, {
       projectRoot: this.projectRoot,
       projectName: this.projectName,
-      podModulePrefix: this.podModulePrefix !== undefined ? this.podModulePrefix : 'pods',
+      podModulePrefix: this.podModulePrefix || '',
       _fileInfoCollection: this._fileInfoCollection
     });
 

--- a/lib/models/file-info.js
+++ b/lib/models/file-info.js
@@ -75,8 +75,6 @@ var FileInfo = CoreObject.extend({
     var pathParts = this.sourceRelativePath.split('/');
     var typeFolder = pathParts[1];
 
-
-
     var podType = typeForPodFile(this.sourceRelativePath);
     var arePodsNamespaced = hasPodNamespace(this.podModulePrefix);
 
@@ -95,15 +93,18 @@ var FileInfo = CoreObject.extend({
       }
     }
 
-    // default/classic/namespaced-pods
-    pathRootRegex = new RegExp('(app\/)?' + this.podModulePrefix + '\/(components\/)?');
+    strippedRelativePath = this.sourceRelativePath;
 
-    strippedRelativePath = this.sourceRelativePath
-      .replace(pathRootRegex, '') // don't care if path begins with pods
+    // default/classic/namespaced-pods
+    if (this.podModulePrefix) {
+      pathRootRegex = new RegExp('(app\/)?' + this.podModulePrefix + '\/(components\/)?');
+      strippedRelativePath = strippedRelativePath.replace(pathRootRegex, ''); // don't care if path begins with pods;
+    }
+
+    strippedRelativePath = strippedRelativePath
       .replace(new RegExp('^' + this.sourceRoot + '/' + typeFolder + '/'), '') // remove leading type dir
       .replace(new RegExp(this.ext + '$'), '') // remove extension
       .replace(new RegExp('/' + this.type + '$'), ''); // remove trailing type
-
 
     if (!arePodsNamespaced) {
       if (podType) {
@@ -120,23 +121,6 @@ var FileInfo = CoreObject.extend({
           .replace(new RegExp(typeFolder + '/'), '') // remove leading type dir
           .replace(new RegExp(this.ext + '$'), '') // remove extension
           .replace(new RegExp('/' + this.type + '$'), ''); // remove trailing type
-      }
-
-      // for other files (adapters, serializers, helpers, initializers, etc)
-      if (type === undefined){
-        pathRootRegex = new RegExp('(app\/)?');
-        type = pathParts[1];
-        fileName = pathParts[pathParts.length - 1];
-        typeFolder = inflection.pluralize(type);
-
-
-        strippedRelativePath = this.sourceRelativePath
-          .replace(pathRootRegex, '')
-          .replace(new RegExp(type + '/'), '')
-          .replace(new RegExp('^' + this.sourceRoot + '/' + typeFolder + '/'), '') // remove leading type dir
-          .replace(new RegExp(this.ext + '$'), '') // remove extension
-          .replace(new RegExp('/' + this.type), ''); // remove trailing type
-
       }
     }
 

--- a/test/fixtures/classic-acceptance/input.js
+++ b/test/fixtures/classic-acceptance/input.js
@@ -97,6 +97,13 @@ module.exports = {
     }
   },
 
+  'config': {
+    'environment.js': '"ENV"',
+    'foo': {
+      'baz.sh': 'yolo'
+    }
+  },
+
   'tests': {
     'acceptance': {
       'post-test.js': '"post acceptance test"'

--- a/test/fixtures/classic-acceptance/output.js
+++ b/test/fixtures/classic-acceptance/output.js
@@ -126,6 +126,12 @@ module.exports = {
       }
     }
   },
+  'config': {
+    'environment.js': '"ENV"',
+    'foo': {
+      'baz.sh': 'yolo'
+    }
+  },
   'tests': {
     'acceptance': {
       'post-test.js': '"post acceptance test"'

--- a/test/fixtures/pods-acceptance/config.js
+++ b/test/fixtures/pods-acceptance/config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  podModulePrefix: 'pods'
+};

--- a/test/fixtures/pods-acceptance/input.js
+++ b/test/fixtures/pods-acceptance/input.js
@@ -96,6 +96,12 @@ module.exports = {
       'blahzorz.js': '"blahzorz validator"'
     }
   },
+  'config': {
+    'environment.js': '"ENV"',
+    'foo': {
+      'baz.sh': 'yolo'
+    }
+  },
   'tests': {
     'acceptance': {
       'post-test.js': '"post acceptance test"'

--- a/test/fixtures/pods-custom-name-acceptance/input.js
+++ b/test/fixtures/pods-custom-name-acceptance/input.js
@@ -96,6 +96,12 @@ module.exports = {
       'blahzorz.js': '"blahzorz validator"'
     }
   },
+  'config': {
+    'environment.js': '"ENV"',
+    'foo': {
+      'baz.sh': 'yolo'
+    }
+  },
   'tests': {
     'acceptance': {
       'post-test.js': '"post acceptance test"'

--- a/test/fixtures/pods-private-components/config.js
+++ b/test/fixtures/pods-private-components/config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  podModulePrefix: 'pods'
+};

--- a/test/fixtures/pods-relative-imports/config.js
+++ b/test/fixtures/pods-relative-imports/config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  podModulePrefix: 'pods'
+};

--- a/test/fixtures/pods-with-undefined-namespace-acceptance/config.js
+++ b/test/fixtures/pods-with-undefined-namespace-acceptance/config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  podModulePrefix: undefined
+};

--- a/test/fixtures/pods-with-undefined-namespace-acceptance/input.js
+++ b/test/fixtures/pods-with-undefined-namespace-acceptance/input.js
@@ -1,0 +1,1 @@
+module.exports = require('../pods-without-namespace-acceptance/input');

--- a/test/fixtures/pods-with-undefined-namespace-acceptance/output.js
+++ b/test/fixtures/pods-with-undefined-namespace-acceptance/output.js
@@ -1,0 +1,1 @@
+module.exports = require('../classic-acceptance/output');

--- a/test/fixtures/pods-without-namespace-acceptance/input.js
+++ b/test/fixtures/pods-without-namespace-acceptance/input.js
@@ -96,6 +96,12 @@ module.exports = {
       'blahzorz.js': '"blahzorz validator"'
     }
   },
+  'config': {
+    'environment.js': '"ENV"',
+    'foo': {
+      'baz.sh': 'yolo'
+    }
+  },
   'tests': {
     'acceptance': {
       'post-test.js': '"post acceptance test"'

--- a/test/models/file-info-test.js
+++ b/test/models/file-info-test.js
@@ -21,6 +21,7 @@ describe('file-info model', function() {
     });
 
     it('can calculate a destRelativePath where the base path is in the pods form', function() {
+      engine.podModulePrefix = 'pods';
       var file = engine.fileInfoFor('app/pods/foo-bar/route.js');
 
       engine.finalizeFileDiscovery();
@@ -118,6 +119,7 @@ describe('file-info model', function() {
       });
 
       it('pods | detecting private / single use components (component only)', function() {
+        engine.podModulePrefix = 'pods';
         var routeTemplate = engine.fileInfoFor('app/pods/posts/index/template.hbs');
         var component = engine.fileInfoFor('app/pods/foo-bar/component.js');
 


### PR DESCRIPTION
When no `podModulePrefix` is specified in environment.js then `podModulePrefix` is `undefined` rather than `'pods'` or `''`.

- Added test for app where `podModulePrefix = undefined`
- Added config files to pod tests
