### PR TITLE
Clean up helpers code

### DIFF
--- a/lib/models/file-info.js
+++ b/lib/models/file-info.js
@@ -7,6 +7,7 @@ var isTypeInSingleTypeCollection = require('../utils/is-type-in-single-type-coll
 var defaultTypeForCollection = require('../utils/default-type-for-collection');
 var calculateCollectionInfo = require('../utils/calculate-collection-info');
 var importDeclarationsTransform = require('../transforms/import-declarations');
+var renameImportHelperTransform = require('../transforms/rename-helper-import');
 var inflection = require('inflection');
 var PodsSupport = require('../utils/pods-support');
 var typeForPodFile = PodsSupport.typeForPodFile;
@@ -173,6 +174,14 @@ var FileInfo = CoreObject.extend({
           fileInfo: this,
           appName: appName,
           fileInfos: this._fileInfoCollection._fileInfos
+        },
+        { jscodeshift });
+
+      // Fixes "import { helper } from '@ember/component/helper'"
+      // to "import { helper as buildHelper } from '@ember/component/helper'"
+      newContents = renameImportHelperTransform(
+        {
+          source: newContents
         },
         { jscodeshift });
 

--- a/lib/transforms/import-declarations.js
+++ b/lib/transforms/import-declarations.js
@@ -5,28 +5,6 @@ function transformer(file, api) {
 
   var root = j(file.source);
 
-  var foundHelper;
-
-  root.find(j.ImportDeclaration, {
-    source: { value: '@ember/component/helper' },
-  }).filter(path => {
-    return path.value.specifiers[0].local.name === 'helper';
-  })
-  .forEach(function(path) {
-    foundHelper = true;
-    var specifier = j.importSpecifier(j.identifier('helper'), j.identifier('buildHelper'));                              
-
-    path.value.specifiers[0] = specifier;
-  });
-  
-  if (foundHelper) {
-    root.find(j.CallExpression, {
-      callee: { name: 'helper' }      
-    }).forEach(path => {
-      path.value.callee.name = 'buildHelper';
-    });
-  }
-
   root.find(j.ImportDeclaration)
     .find(j.Literal)
     .forEach(function(path) {

--- a/lib/transforms/rename-helper-import.js
+++ b/lib/transforms/rename-helper-import.js
@@ -1,0 +1,39 @@
+function transformer(file, api) {
+  var j = api.jscodeshift;
+
+  var foundHelper = false;
+
+  var root = j(file.source);
+
+  // Replaces:
+  //   import { helper } from '@ember/component/helper';
+  // With:
+  //   import { helper as buildHelper } from '@ember/component/helper';
+  root.find(j.ImportDeclaration, {
+    source: { value: '@ember/component/helper' },
+  }).filter(path => {
+    return path.value.specifiers[0].local.name === 'helper';
+  })
+  .forEach(function(path) {
+    foundHelper = true;
+    var specifier = j.importSpecifier(
+      j.identifier('helper'),
+      j.identifier('buildHelper')
+    );
+
+    path.value.specifiers[0] = specifier;
+  });
+  
+  // Replace helper(...) with buildHelper(...)
+  if (foundHelper) {
+    root.find(j.CallExpression, {
+      callee: { name: 'helper' }      
+    }).forEach(path => {
+      path.value.callee.name = 'buildHelper';
+    });
+  }
+
+  return root.toSource();
+}
+
+module.exports = transformer;

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "license": "MIT",
   "devDependencies": {
     "assert-diff": "^1.0.1",
+    "common-tags": "^1.7.2",
     "espower-loader": "^1.0.0",
     "fixturify": "^0.3.3",
     "jscodeshift": "^0.3.30",

--- a/test/fixtures/classic-acceptance/input.js
+++ b/test/fixtures/classic-acceptance/input.js
@@ -1,3 +1,5 @@
+var stripIndents = require('common-tags').stripIndents;
+
 module.exports = {
   'app': {
     'app.js': '"app.js"',
@@ -19,10 +21,22 @@ module.exports = {
       }
     },
     'helpers': {
-      'i18n.js': '"i18n helper"',
-      'blerg.js': '"blerg helper"',
-      'main-greeting-text.js': '"main-greeting-text helper"',
-      'show-default-title.js': '"show-default-title helper"'
+      'i18n.js': stripIndents`
+        import { helper } from '@ember/component/helper';
+        export default helper(i18n);
+      `,
+      'blerg.js': stripIndents`
+        import { helper } from '@ember/component/helper';
+        export default helper(blerg);
+      `,
+      'main-greeting-text.js': stripIndents`
+        import { helper } from '@ember/component/helper';
+        export default helper(mainGreetingText);
+      `,
+      'show-default-title.js': stripIndents`
+        import { helper } from '@ember/component/helper';
+        export default helper(showDefaultTitle);
+      `,
     },
     'routes': {
       'index.js': '"index route"',

--- a/test/fixtures/classic-acceptance/output.js
+++ b/test/fixtures/classic-acceptance/output.js
@@ -1,3 +1,5 @@
+var stripIndents = require('common-tags').stripIndents;
+
 module.exports = {
   'src': {
     'main.js': '"app.js"',
@@ -22,13 +24,22 @@ module.exports = {
           'component.js': '"baz-derp component"',
           'template.hbs': 'baz-derp template'
         },
-        'i18n.js': '"i18n helper"',
-        'blerg.js': '"blerg helper"'
+        'i18n.js': stripIndents`
+          import { helper as buildHelper } from '@ember/component/helper';
+          export const helper = buildHelper(i18n);
+        `,
+        'blerg.js': stripIndents`
+          import { helper as buildHelper } from '@ember/component/helper';
+          export const helper = buildHelper(blerg);
+        `,
       },
       'routes': {
         'index': {
           '-components': {
-            'main-greeting-text.js': '"main-greeting-text helper"'
+            'main-greeting-text.js': stripIndents`
+              import { helper as buildHelper } from '@ember/component/helper';
+              export const helper = buildHelper(mainGreetingText);
+            `
           },
           'controller.js': '"index controller"',
           'route.js': '"index route"',
@@ -72,7 +83,10 @@ module.exports = {
           'new': {
             '-components': {
               'show-default-title': {
-                'helper.js': '"show-default-title helper"',
+                'helper.js': stripIndents`
+                  import { helper as buildHelper } from '@ember/component/helper';
+                  export default buildHelper(showDefaultTitle);
+                `,
                 'helper-integration-test.js': '"show-default-title helper integration test"'
               }
             },

--- a/test/fixtures/classic-named-exports/input.js
+++ b/test/fixtures/classic-named-exports/input.js
@@ -1,11 +1,19 @@
+var stripIndents = require('common-tags').stripIndents;
+
 module.exports = {
   app: {
     // ensure we do not rewrite main files
     'app.js': 'export default App',
     'router.js': 'export default Router',
     helpers: {
-      'titleize.js': 'import { helper } from \'@ember/component/helper\';\nexport default helper(function() { });',
-      'capitalize.js': 'import { helper } from \'@ember/component/helper\';\nexport default helper(function() { });'
+      'titleize.js': stripIndents`
+        import { helper } from '@ember/component/helper';
+        export default helper(function() { });
+      `,
+      'capitalize.js': stripIndents`
+        import { helper } from '@ember/component/helper';
+        export default helper(function() { });
+      `
     }
   },
 

--- a/test/fixtures/classic-named-exports/output.js
+++ b/test/fixtures/classic-named-exports/output.js
@@ -1,12 +1,20 @@
+var stripIndents = require('common-tags').stripIndents;
+
 module.exports = {
   src: {
     'main.js': 'export default App',
     'router.js': 'export default Router',
     ui: {
       components: {
-        'titleize.js': 'import { helper as buildHelper } from \'@ember/component/helper\';\nexport const helper = buildHelper(function() { });',
+        'titleize.js': stripIndents`
+          import { helper as buildHelper } from '@ember/component/helper';
+          export const helper = buildHelper(function() { });
+        `,
         'capitalize': {
-          'helper.js': 'import { helper as buildHelper } from \'@ember/component/helper\';\nexport default buildHelper(function() { });',
+          'helper.js': stripIndents`
+            import { helper as buildHelper } from '@ember/component/helper';
+            export default buildHelper(function() { });
+          `,
           'helper-integration-test.js': '"capitalize helper test"'
         }
       }

--- a/test/fixtures/pods-acceptance/input.js
+++ b/test/fixtures/pods-acceptance/input.js
@@ -1,3 +1,5 @@
+var stripIndents = require('common-tags').stripIndents;
+
 module.exports = {
   'app': {
     'app.js': '"app.js"',
@@ -56,10 +58,22 @@ module.exports = {
       },
     },
     'helpers': {
-      'i18n.js': '"i18n helper"',
-      'blerg.js': '"blerg helper"',
-      'main-greeting-text.js': '"main-greeting-text helper"',
-      'show-default-title.js': '"show-default-title helper"'
+      'i18n.js': stripIndents`
+        import { helper } from '@ember/component/helper';
+        export default helper(i18n);
+      `,
+      'blerg.js': stripIndents`
+        import { helper } from '@ember/component/helper';
+        export default helper(blerg);
+      `,
+      'main-greeting-text.js': stripIndents`
+        import { helper } from '@ember/component/helper';
+        export default helper(mainGreetingText);
+      `,
+      'show-default-title.js': stripIndents`
+        import { helper } from '@ember/component/helper';
+        export default helper(showDefaultTitle);
+      `,
     },
     'adapters': {
       'application.js': '"application adapter"',

--- a/test/fixtures/pods-custom-name-acceptance/input.js
+++ b/test/fixtures/pods-custom-name-acceptance/input.js
@@ -1,3 +1,5 @@
+var stripIndents = require('common-tags').stripIndents;
+
 module.exports = {
   'app': {
     'app.js': '"app.js"',
@@ -56,10 +58,22 @@ module.exports = {
       },
     },
     'helpers': {
-      'i18n.js': '"i18n helper"',
-      'blerg.js': '"blerg helper"',
-      'main-greeting-text.js': '"main-greeting-text helper"',
-      'show-default-title.js': '"show-default-title helper"'
+      'i18n.js': stripIndents`
+        import { helper } from '@ember/component/helper';
+        export default helper(i18n);
+      `,
+      'blerg.js': stripIndents`
+        import { helper } from '@ember/component/helper';
+        export default helper(blerg);
+      `,
+      'main-greeting-text.js': stripIndents`
+        import { helper } from '@ember/component/helper';
+        export default helper(mainGreetingText);
+      `,
+      'show-default-title.js': stripIndents`
+        import { helper } from '@ember/component/helper';
+        export default helper(showDefaultTitle);
+      `,
     },
     'adapters': {
       'application.js': '"application adapter"',

--- a/test/fixtures/pods-without-namespace-acceptance/input.js
+++ b/test/fixtures/pods-without-namespace-acceptance/input.js
@@ -1,3 +1,5 @@
+var stripIndents = require('common-tags').stripIndents;
+
 module.exports = {
   'app': {
     'app.js': '"app.js"',
@@ -54,10 +56,22 @@ module.exports = {
       },
     },
     'helpers': {
-      'i18n.js': '"i18n helper"',
-      'blerg.js': '"blerg helper"',
-      'main-greeting-text.js': '"main-greeting-text helper"',
-      'show-default-title.js': '"show-default-title helper"'
+      'i18n.js': stripIndents`
+        import { helper } from '@ember/component/helper';
+        export default helper(i18n);
+      `,
+      'blerg.js': stripIndents`
+        import { helper } from '@ember/component/helper';
+        export default helper(blerg);
+      `,
+      'main-greeting-text.js': stripIndents`
+        import { helper } from '@ember/component/helper';
+        export default helper(mainGreetingText);
+      `,
+      'show-default-title.js': stripIndents`
+        import { helper } from '@ember/component/helper';
+        export default helper(showDefaultTitle);
+      `,
     },
     'post': {
       'adapter.js': '"post adapter"',

--- a/yarn.lock
+++ b/yarn.lock
@@ -818,6 +818,13 @@ babel-runtime@^6.18.0, babel-runtime@^6.22.0:
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
 
+babel-runtime@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
+  dependencies:
+    core-js "^2.4.0"
+    regenerator-runtime "^0.11.0"
+
 babel-template@^6.24.1, babel-template@^6.25.0:
   version "6.25.0"
   resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.25.0.tgz#665241166b7c2aa4c619d71e192969552b10c071"
@@ -1014,6 +1021,12 @@ commander@2.9.0, commander@^2.5.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
   dependencies:
     graceful-readlink ">= 1.0.0"
+
+common-tags@^1.7.2:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/common-tags/-/common-tags-1.7.2.tgz#24d9768c63d253a56ecff93845b44b4df1d52771"
+  dependencies:
+    babel-runtime "^6.26.0"
 
 commoner@~0.10.3:
   version "0.10.8"
@@ -2477,6 +2490,10 @@ regenerate@^1.2.1:
 regenerator-runtime@^0.10.0:
   version "0.10.5"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
+
+regenerator-runtime@^0.11.0:
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
 
 regenerator-transform@0.9.11:
   version "0.9.11"


### PR DESCRIPTION
This follows on #69 to clean it up a little bit.

  * Add "import { helper } from '@ember/component/helper" and an export to all the helpers in fixtures inputs
  * Update the corresponding expectation in the fixtures outputs
  * Add common-tags as a devDep to allow using `stripIndents`
  * Extract the helper codemod code to a separate file
  * Modify lib/models/file-info.js to apply the helper codemod to the output of the `importDeclarationsTransform`