### PR TITLE
classic template-only component test

### DIFF
--- a/test/fixtures/classic-template-only-component/input.js
+++ b/test/fixtures/classic-template-only-component/input.js
@@ -1,0 +1,9 @@
+module.exports = {
+  app: {
+    templates: {
+      components: {
+        'x-button.hbs': 'x-button template',
+      }
+    }
+  }
+};

--- a/test/fixtures/classic-template-only-component/output.js
+++ b/test/fixtures/classic-template-only-component/output.js
@@ -1,0 +1,11 @@
+module.exports = {
+  src: {
+    ui: {
+      components: {
+        'x-button': {
+          'template.hbs': 'x-button template'
+        }
+      }
+    }
+  }
+};


### PR DESCRIPTION
An issue was raised in the [Module Unification Quest Issue](https://github.com/emberjs/ember.js/issues/16373) that "The migrator currently renames template-only components to not have a folder, like src/ui/components/name.hbs." However I can't reproduce this and added another test to confirm. There are many tests in this repo already with template-only components, and they all output to something like `x-bar/template.hbs` rather than `x-bar.hbs`, for example https://github.com/rwjblue/ember-module-migrator/tree/master/test/fixtures/classic-private-components