### PR TITLE
migrate test-helpers.js to import APP from src/main

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,11 +95,14 @@ loadInitializers(App, config.modulePrefix+'/src/init');
 loadInitializers(App, config.modulePrefix);
 ```
 
-Finally, in `tests/test-helper.js`, load the app from `../src/main`
+### Running Tests
 
-```js
-import Application from '../src/main';
-```
+ * `npm run test`
+
+To debug tests:
+
+  * All tests: `mocha --debug-brk --inspect test/**/*-test.js`
+  * A single test: `mocha --debug-brk --inspect test/**/*-test.js --grep test-helpers`
 
 ### Important Notes
 

--- a/lib/engines/classic/index.js
+++ b/lib/engines/classic/index.js
@@ -112,6 +112,8 @@ module.exports = {
         options.type = testType;
         options.base = 'tests';
         return new ClassicFileInfo(options);
+      } else {
+        return new MiscFileInfo(options);
       }
     } else if (sourceRoot === 'config') {
       return new ConfigFileInfo(options);

--- a/test/fixtures/qunit-module-test-helpers/input.js
+++ b/test/fixtures/qunit-module-test-helpers/input.js
@@ -1,0 +1,20 @@
+module.exports = {
+  app: {
+    'app.js': '// app',
+    'resolver.js': '// resolver',
+    adapters: {
+      '.eslint.js': '{}'
+    }
+  },
+  config: {
+    'environment.js': '"ENV"'
+  },
+  tests: {
+    '.eslintrc.js': 'module.exports = {};',
+    '.eslint.js': '{}',
+    'test-helper.js': 'import App from "../app";',
+    helpers: {
+      'resolver.js': 'import Resolver from "../../resolver";'
+    }
+  }
+};

--- a/test/fixtures/qunit-module-test-helpers/output.js
+++ b/test/fixtures/qunit-module-test-helpers/output.js
@@ -1,0 +1,22 @@
+module.exports = {
+  app: {
+    adapters: {
+      '.eslint.js': '{}'
+    }
+  },
+  src: {
+    'main.js': '// app',
+    'resolver.js': '// resolver'
+  },
+  config: {
+    'environment.js': '"ENV"'
+  },
+  tests: {
+    '.eslintrc.js': 'module.exports = {};',
+    '.eslint.js': '{}',
+    'test-helper.js': 'import App from "../src/main";',
+    'helpers': {
+      'resolver.js': 'import Resolver from "../../src/resolver";'
+    }
+  }
+};


### PR DESCRIPTION
Migrate test-helpers.js to import APP from src/main. This means we can remove the manual step from the README.

Fixes the 1st migrator bullet in https://github.com/emberjs/ember.js/issues/16373

There's a separate but similar fixture called [`test-helpers`](https://github.com/rwjblue/ember-module-migrator/tree/master/test/fixtures/test-helpers) which I left unchanged. That test has a `start-app.js` file so it's for apps that haven't migrating to the new testing structure. This new test has no `start-app.js` and thus the App import is done in `test-helper.js`.